### PR TITLE
Refactored code to make use of interface generics from monaco-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "packageManager": "pnpm@8.9.0",
   "scripts": {
-    "generate": "rm -rf ./src/proto && node generate.js",
+    "generate": "rm -rf ./src/api/proto && node generate.js",
     "rollup": "rollup -c",
     "clean": "rm -rf node_modules && rm -rf dist",
     "test": "echo \"Error: no test specified\" && exit 1",

--- a/src/components/CodeiumEditor/InlineCompletion.ts
+++ b/src/components/CodeiumEditor/InlineCompletion.ts
@@ -1,0 +1,26 @@
+import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+
+export default class MonacoInlineCompletion
+  implements monaco.languages.InlineCompletion
+{
+  readonly insertText: string;
+  // TODO(prem): Why is this property needed?
+  readonly text: string;
+  readonly range: monaco.IRange;
+  readonly command: {
+    id: string;
+    title: string;
+    arguments: string[];
+  };
+
+  constructor(insertText: string, range: monaco.IRange, completionId: string) {
+    this.insertText = insertText;
+    this.text = insertText;
+    this.range = range;
+    this.command = {
+      id: "codeium.acceptCompletion",
+      title: "Accept Completion",
+      arguments: [completionId, insertText],
+    };
+  }
+}

--- a/src/components/CodeiumEditor/InlineCompletionProvider.ts
+++ b/src/components/CodeiumEditor/InlineCompletionProvider.ts
@@ -4,6 +4,7 @@ import { PromiseClient } from "@connectrpc/connect";
 import { Status } from "./Status";
 import { MonacoCompletionProvider } from "./CompletionProvider";
 import { LanguageServerService } from "../../api/proto/exa/language_server_pb/language_server_connect";
+import MonacoInlineCompletion from "./InlineCompletion";
 
 declare module "monaco-editor" {
   namespace editor {
@@ -14,7 +15,10 @@ declare module "monaco-editor" {
 }
 
 export class InlineCompletionProvider
-  implements monaco.languages.InlineCompletionsProvider
+  implements
+    monaco.languages.InlineCompletionsProvider<
+      monaco.languages.InlineCompletions<MonacoInlineCompletion>
+    >
 {
   private numCompletionsProvided: number;
   readonly completionProvider: MonacoCompletionProvider;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "declarationDir": "types",
     "sourceMap": true,
     "outDir": "dist",
-    "moduleResolution": "node",
+    "moduleResolution": "Bundler",
     "allowSyntheticDefaultImports": true,
     "emitDeclarationOnly": true
   }


### PR DESCRIPTION
Refactored `MonacoInlineCompletion` into its own file to reuse the class to redefine some interfaces as interface generics  in accordance with the `monaco-editor` API because `MonacoInlineCompletion` is after all an implementation of the `monaco.languages.InlineCompletion` interface. 

Also added the following type-guard for `inlineCompletionItems` to remove the type assertion `as monaco.languages.InlineCompletion[]`

```ts
      .filter(
        (item?: MonacoInlineCompletion): item is MonacoInlineCompletion =>
          !!item
      );
```