### PR TITLE
Enable context from other documents

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Here's an advanced example that uses multi-document context to provide more inte
 ```tsx
 import { CodeiumEditor, Document, Language } from "@codeium/react-code-editor";
 
-export const JavascriptEditorWithContext = () => {
+export const JavaScriptEditorWithContext = () => {
   const html = `<html>
   <body>
     <h1>Contact Us</h1>
@@ -85,6 +85,8 @@ export const JavascriptEditorWithContext = () => {
   );
 };
 ```
+
+Note that the `otherDocuments` prop has a limit of 10 documents. Within those documents, Codeium will run a reranker behind the scenes to optimize what is included in the token limit.
 
 ### Examples
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,45 @@ export const IdeWithAutocomplete = () => {
 };
 ```
 
+Here's an advanced example that uses multi-document context to provide more intelligent autocompletion:
+
+```tsx
+import { CodeiumEditor, Document, Language } from "@codeium/react-code-editor";
+
+export const JavascriptEditorWithContext = () => {
+  const html = `<html>
+  <body>
+    <h1>Contact Us</h1>
+    <form>
+      <label>Name:</label>
+      <input id="name" type="text" />
+      <label>Email:</label>
+      <input id="email" type="text" />
+    </form>
+  </body>
+</html>`;
+
+  return (
+    <div>
+      <p>This editor has context awareness of a neighboring HTML file and can provide better autocompletion suggestions.</p>
+      <CodeiumEditor
+        language="javascript"
+        theme="vs-dark"
+        otherDocuments={[
+          new Document({
+            absolutePath: "/app/index.html",
+            relativePath: "index.html",
+            text: html,
+            editorLanguage: "html",
+            language: Language.HTML,
+          }),
+        ]}
+      />
+    </div>
+  );
+};
+```
+
 ### Examples
 
 Here are some examples of Codeium React Editor used in production:
@@ -70,11 +109,12 @@ The core API of the editor is the same as that of the wrapped project. You can v
 ## FAQ
 
 #### How can I import the ESM version of this?
+
 To import the ESM version of this, you can use `import { CodeiumEditor } from "@codeium/react-code-editor/dist/esm";`. If you're using TypeScript, your editor might warn that the types are missing. A current workaround is:
+
 - Create a `codeiumeditor.d.ts` file,
 - Add `declare module '@codeium/react-code-editor/dist/esm';` to the file
 - Import the types file in the file using the `CodeiumEditor` component.
-
 
 This is an open issue in terms of supporting both CommonJS and ESM. If you're interested in contributing and have a fix for this, pull requests are welcome.
 

--- a/src/components/CodeiumEditor/CodeiumEditor.tsx
+++ b/src/components/CodeiumEditor/CodeiumEditor.tsx
@@ -11,6 +11,7 @@ import { getDefaultValue } from "./defaultValues";
 import { LanguageServerService } from "../../api/proto/exa/language_server_pb/language_server_connect";
 import { InlineCompletionProvider } from "./InlineCompletionProvider";
 import { CodeiumLogo } from "../CodeiumLogo/CodeiumLogo";
+import { Document } from "../../models";
 
 export interface CodeiumEditorProps extends EditorProps {
   language: string;
@@ -25,6 +26,13 @@ export interface CodeiumEditorProps extends EditorProps {
    * to Codeium's language server.
    */
   languageServerAddress?: string;
+
+  /**
+   * Optional list of other documents in the workspace. This can be used to provide additional
+   * context to Codeium beyond simply the current document. There is a limit of 10 medium sized
+   * documents.
+   */
+  otherDocuments?: Document[];
 }
 
 /**
@@ -33,6 +41,7 @@ export interface CodeiumEditorProps extends EditorProps {
  */
 export const CodeiumEditor: React.FC<CodeiumEditorProps> = ({
   languageServerAddress = "https://web-backend.codeium.com",
+  otherDocuments = [],
   ...props
 }) => {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
@@ -131,6 +140,11 @@ export const CodeiumEditor: React.FC<CodeiumEditorProps> = ({
       props.onMount(editor, monaco);
     }
   };
+
+  // Keep other documents up to date.
+  useEffect(() => {
+    inlineCompletionsProviderRef.current?.updateOtherDocuments(otherDocuments);
+  }, [otherDocuments]);
 
   let defaultLanguageProps: EditorProps = {
     defaultLanguage: props.language,

--- a/src/components/CodeiumEditor/CompletionProvider.ts
+++ b/src/components/CodeiumEditor/CompletionProvider.ts
@@ -52,6 +52,11 @@ export class MonacoCompletionProvider {
   private client: PromiseClient<typeof LanguageServerService>;
   private sessionId: string;
 
+  /**
+   * A list of other documents to include as context in the prompt.
+   */
+  public otherDocuments: DocumentInfo[] = [];
+
   constructor(
     grpcClient: PromiseClient<typeof LanguageServerService>,
     readonly setStatus: (status: Status) => void,
@@ -119,6 +124,14 @@ export class MonacoCompletionProvider {
       insertSpaces: model.getOptions().insertSpaces,
     };
 
+    let includedOtherDocs = this.otherDocuments;
+    if (includedOtherDocs.length > 10) {
+      console.warn(
+        `Too many other documents: ${includedOtherDocs.length} (max 10)`
+      );
+      includedOtherDocs = includedOtherDocs.slice(0, 10);
+    }
+
     // Get completions.
     let getCompletionsResponse: GetCompletionsResponse;
     try {
@@ -127,6 +140,7 @@ export class MonacoCompletionProvider {
           metadata: this.getMetadata(),
           document: documentInfo,
           editorOptions: editorOptions,
+          otherDocuments: includedOtherDocs,
         },
         {
           signal,

--- a/src/components/CodeiumEditor/CompletionProvider.ts
+++ b/src/components/CodeiumEditor/CompletionProvider.ts
@@ -131,6 +131,10 @@ export class MonacoCompletionProvider {
       );
       includedOtherDocs = includedOtherDocs.slice(0, 10);
     }
+    console.log(
+      `Included other documents: ${includedOtherDocs.length}`,
+      includedOtherDocs.map((d) => d.toJson())
+    );
 
     // Get completions.
     let getCompletionsResponse: GetCompletionsResponse;

--- a/src/components/CodeiumEditor/InlineCompletionProvider.ts
+++ b/src/components/CodeiumEditor/InlineCompletionProvider.ts
@@ -1,4 +1,5 @@
 import * as monaco from "monaco-editor/esm/vs/editor/editor.api";
+import { Document as DocumentInfo } from "../../api/proto/exa/language_server_pb/language_server_pb";
 import { Dispatch, SetStateAction } from "react";
 import { PromiseClient } from "@connectrpc/connect";
 import { Status } from "./Status";
@@ -18,6 +19,7 @@ export class InlineCompletionProvider
 {
   private numCompletionsProvided: number;
   readonly completionProvider: MonacoCompletionProvider;
+
   constructor(
     grpcClient: PromiseClient<typeof LanguageServerService>,
     readonly setCompletionCount: Dispatch<SetStateAction<number>>,
@@ -62,5 +64,9 @@ export class InlineCompletionProvider
 
   public acceptedLastCompletion(completionId: string) {
     this.completionProvider.acceptedLastCompletion(completionId);
+  }
+
+  public updateOtherDocuments(otherDocuments: DocumentInfo[]) {
+    this.completionProvider.otherDocuments = otherDocuments;
   }
 }

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,1 +1,2 @@
 export { Language } from "../api/proto/exa/codeium_common_pb/codeium_common_pb";
+export { Document } from "../api/proto/exa/language_server_pb/language_server_pb";

--- a/src/stories/CodeiumEditor.stories.tsx
+++ b/src/stories/CodeiumEditor.stories.tsx
@@ -168,11 +168,13 @@ export const MultiFileContext: Story = {
     ...baseParams,
     language: "javascript",
     value: `// You have context over a sample HTML page.
-// Codeium's generation will take this context into account when suggesting.`,
+// Codeium's generation will take this context into account when suggesting.
+
+// Get the contact form values by ID.`,
     otherDocuments: [
       new Document({
         absolutePath: "/index.html",
-        relativePath: "/index.html",
+        relativePath: "index.html",
         text: HTML_SNIPPET,
         editorLanguage: "html",
         language: Language.HTML,

--- a/src/stories/CodeiumEditor.stories.tsx
+++ b/src/stories/CodeiumEditor.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
 
 import { CodeiumEditor } from "../components";
+import { Document, Language } from "../models";
 
 // More on how to set up stories at: https://storybook.js.org/docs/writing-stories#default-export
 const meta: Meta<typeof CodeiumEditor> = {
@@ -20,9 +22,9 @@ export default meta;
 type Story = StoryObj<typeof meta>;
 
 const baseParams = {
-    width: "700px",
-    height: "500px",
-}
+  width: "700px",
+  height: "500px",
+};
 
 const PYTHON_SNIPPET = `# Need inspiration? Try adding extra constraints or context to this parse json function!
 # Or scratch everything and use your imagination.
@@ -30,14 +32,14 @@ const PYTHON_SNIPPET = `# Need inspiration? Try adding extra constraints or cont
 def parse_json_lines(filename: str) -> List[Any]:
     output = []
     with open(filename, "r", encoding="utf-8") as f:
-`
+`;
 
 // More on writing stories with args: https://storybook.js.org/docs/writing-stories/args
 export const PythonEditor: Story = {
   args: {
     ...baseParams,
     language: "python",
-    value: PYTHON_SNIPPET
+    value: PYTHON_SNIPPET,
   },
 };
 
@@ -47,13 +49,13 @@ const JAVASCRIPT_SNIPPET = `
 
 // Convert HTML string to DOM object
 function parseStringAsHtml(content, selector) {
-`
+`;
 
 export const JavaScriptEditor: Story = {
   args: {
     ...baseParams,
     language: "javascript",
-    value: JAVASCRIPT_SNIPPET 
+    value: JAVASCRIPT_SNIPPET,
   },
 };
 
@@ -70,12 +72,12 @@ import (
 
 func main() {
     // Configure log and create a new logger
-`
+`;
 export const GoEditor: Story = {
   args: {
     ...baseParams,
     language: "go",
-    value:  GO_SNIPPET
+    value: GO_SNIPPET,
   },
 };
 
@@ -88,16 +90,15 @@ const JAVA_SNIPPET = `
  * @return ArrayList of all visible widgets
  */
 public ArrayList<Widget> getVisibleWidgets() {
-`
+`;
 
 export const JavaEditor: Story = {
   args: {
     ...baseParams,
     language: "java",
-    value:  JAVA_SNIPPET
+    value: JAVA_SNIPPET,
   },
 };
-
 
 const CPP_SNIPPET = `
 // Need inspiration? Try finishing this Matrix class with constructors,
@@ -109,13 +110,73 @@ template <class T>
 class Matrix() {
  public:
   Matrix(int rows, int cols) {
-`
+`;
 
 export const CppEditor: Story = {
   args: {
     ...baseParams,
     language: "cpp",
-    value:  CPP_SNIPPET
+    value: CPP_SNIPPET,
   },
 };
 
+const HTML_SNIPPET = `<html>
+  <head>
+    <title>Contact Form</title>
+  </head>
+  <body>
+    <h1>Contact Form</h1>
+    <p>I'm a simple contact form.</p>
+
+    <form>
+      <label for="name">Name:</label>
+      <input type="text" id="name-field-id" name="name" />
+
+      <label for="email">Email:</label>
+      <input type="email" id="email-field-id" name="email" />
+    </form>
+  </body>
+</html>
+`;
+
+export const HTMLEditor: Story = {
+  args: {
+    ...baseParams,
+    language: "html",
+    value: HTML_SNIPPET,
+  },
+};
+
+export const MultiFileContext: Story = {
+  decorators: (Story) => (
+    <div>
+      <h1>Multi File Context</h1>
+      <p>
+        Neighboring file at <code>index.html</code> passed into the{" "}
+        <code>otherDocuments</code> property:
+      </p>
+      <code>
+        <pre>{HTML_SNIPPET}</pre>
+      </code>
+      <div>
+        <h3>Context Aware Editor</h3>
+        <Story />
+      </div>
+    </div>
+  ),
+  args: {
+    ...baseParams,
+    language: "javascript",
+    value: `// You have context over a sample HTML page.
+// Codeium's generation will take this context into account when suggesting.`,
+    otherDocuments: [
+      new Document({
+        absolutePath: "/index.html",
+        relativePath: "/index.html",
+        text: HTML_SNIPPET,
+        editorLanguage: "html",
+        language: Language.HTML,
+      }),
+    ],
+  },
+};


### PR DESCRIPTION
Enable `otherDocuments` property which will allow the user to pass in relevant file context. Example:

<img width="855" alt="Screenshot 2024-02-12 at 10 50 46 PM" src="https://github.com/Exafunction/codeium-react-code-editor/assets/6607077/830c9f51-737f-4acd-8c43-1ccdf8abd050">


### Usage

Use the new `otherDocs` prop. For example:

```typescript
<CodeiumEditor
  language="javascript"
  otherDocuments={[
    new Document({
      absolutePath: "/index.html",
      relativePath: "index.html",
      text: "the contents of the html file...",
      editorLanguage: "html",
      language: Language.HTML,
    }),
  ]}
/>
```