### PR TITLE
Enable multiline model threshold preference

### DIFF
--- a/exa/language_server_pb/language_server.proto
+++ b/exa/language_server_pb/language_server.proto
@@ -15,6 +15,12 @@ service LanguageServerService {
   rpc GetAuthToken(GetAuthTokenRequest) returns (GetAuthTokenResponse) {}
 }
 
+message MultilineConfig {
+  // Multiline model threshold. 0-1, higher = more single line, lower = more multiline,
+  // 0.0 = only_multiline, default is 0.5
+  float threshold = 1;
+}
+
 // Next ID: 9, Previous field: disable_cache.
 message GetCompletionsRequest {
   codeium_common_pb.Metadata metadata = 1 [(validate.rules).message.required = true];
@@ -24,6 +30,7 @@ message GetCompletionsRequest {
   ExperimentConfig experiment_config = 7;
 
   string model_name = 10;
+  MultilineConfig multiline_config = 13;
 }
 
 // Next ID: 5, Previous field: latency_info.

--- a/src/components/CodeiumEditor/CodeiumEditor.tsx
+++ b/src/components/CodeiumEditor/CodeiumEditor.tsx
@@ -48,7 +48,7 @@ export interface CodeiumEditorProps extends EditorProps {
   /**
    * Optional multiline model threshold. Should not be needed for most use cases.
    * Numerical value between 0-1, higher = more single line, lower = more multiline,
-   * 0.0 = only_multiline, default is 0.5.
+   * 0.0 = only_multiline.
    */
   multilineModelThreshold?: number;
 }

--- a/src/components/CodeiumEditor/CodeiumEditor.tsx
+++ b/src/components/CodeiumEditor/CodeiumEditor.tsx
@@ -44,6 +44,13 @@ export interface CodeiumEditorProps extends EditorProps {
    * Optional styles for the container.
    */
   containerStyle?: React.CSSProperties;
+
+  /**
+   * Optional multiline model threshold. Should not be needed for most use cases.
+   * Numerical value between 0-1, higher = more single line, lower = more multiline,
+   * 0.0 = only_multiline, default is 0.5.
+   */
+  multilineModelThreshold?: number;
 }
 
 /**
@@ -86,6 +93,7 @@ export const CodeiumEditor: React.FC<CodeiumEditorProps> = ({
       setCodeiumStatus,
       setCodeiumStatusMessage,
       props.apiKey,
+      props.multilineModelThreshold,
     );
   }, []);
 

--- a/src/components/CodeiumEditor/CompletionProvider.ts
+++ b/src/components/CodeiumEditor/CompletionProvider.ts
@@ -62,6 +62,7 @@ export class MonacoCompletionProvider {
     readonly setStatus: (status: Status) => void,
     readonly setMessage: (message: string) => void,
     readonly apiKey?: string | undefined,
+    readonly multilineModelThreshold?: number | undefined,
   ) {
     this.sessionId = `react-editor-${uuid()}`;
     this.client = grpcClient;
@@ -141,6 +142,11 @@ export class MonacoCompletionProvider {
           document: documentInfo,
           editorOptions: editorOptions,
           otherDocuments: includedOtherDocs,
+          multilineConfig: this.multilineModelThreshold
+            ? {
+                threshold: this.multilineModelThreshold,
+              }
+            : undefined,
         },
         {
           signal,

--- a/src/components/CodeiumEditor/CompletionProvider.ts
+++ b/src/components/CodeiumEditor/CompletionProvider.ts
@@ -4,6 +4,7 @@ import {
   Document as DocumentInfo,
   GetCompletionsResponse,
   CompletionItem,
+  MultilineConfig,
 } from '../../api/proto/exa/language_server_pb/language_server_pb';
 import { Document } from './Document';
 import { Position, Range } from './Location';
@@ -133,6 +134,13 @@ export class MonacoCompletionProvider {
       includedOtherDocs = includedOtherDocs.slice(0, 10);
     }
 
+    let multilineConfig: MultilineConfig | undefined = undefined;
+    if (this.multilineModelThreshold !== undefined) {
+      multilineConfig = new MultilineConfig({
+        threshold: this.multilineModelThreshold,
+      });
+    }
+
     // Get completions.
     let getCompletionsResponse: GetCompletionsResponse;
     try {
@@ -142,11 +150,7 @@ export class MonacoCompletionProvider {
           document: documentInfo,
           editorOptions: editorOptions,
           otherDocuments: includedOtherDocs,
-          multilineConfig: this.multilineModelThreshold
-            ? {
-                threshold: this.multilineModelThreshold,
-              }
-            : undefined,
+          multilineConfig,
         },
         {
           signal,

--- a/src/components/CodeiumEditor/InlineCompletionProvider.ts
+++ b/src/components/CodeiumEditor/InlineCompletionProvider.ts
@@ -26,6 +26,7 @@ export class InlineCompletionProvider
     setCodeiumStatus: Dispatch<SetStateAction<Status>>,
     setCodeiumStatusMessage: Dispatch<SetStateAction<string>>,
     apiKey?: string | undefined,
+    multilineModelThreshold?: number | undefined,
   ) {
     this.numCompletionsProvided = 0;
     this.completionProvider = new MonacoCompletionProvider(
@@ -33,6 +34,7 @@ export class InlineCompletionProvider
       setCodeiumStatus,
       setCodeiumStatusMessage,
       apiKey,
+      multilineModelThreshold,
     );
   }
 

--- a/src/stories/CodeiumEditor.stories.tsx
+++ b/src/stories/CodeiumEditor.stories.tsx
@@ -159,6 +159,7 @@ export const PlainTextEditor: Story = {
     ...baseParams,
     language: 'markdown',
     value: 'This is a test textarea. Lorem',
+    multilineModelThreshold: 1.0,
     containerStyle: {
       border: '1px solid black',
       borderRadius: '2px',


### PR DESCRIPTION
Gives the user the ability to specify their multiline vs. singleline preference via `multilineModelThreshold` prop.

```proto
// Multiline model threshold. 0-1, higher = more single line, lower = more multiline,
// 0.0 = only_multiline, default is 0.5
```

CC = @pavanchitta @mraheja 